### PR TITLE
Added non-nlr orthogoups computed separately;

### DIFF
--- a/results/orthogroups/non-nlrome.filtered.groups
+++ b/results/orthogroups/non-nlrome.filtered.groups
@@ -1,0 +1,1 @@
+/ebio/abt6_projects8/Ath_Rgenes_pipeline/data/publish/non-nlr-orthogroups/non-nlrs.groups


### PR DESCRIPTION
Generated orthogroups for all non-nlrs from the nlromes plus all Araport11 non-nlrs using diamond, orthAgogue and mcl.